### PR TITLE
Really remove the gift button

### DIFF
--- a/adblock.css
+++ b/adblock.css
@@ -20,7 +20,7 @@
 
   /*  Hide gift button*/
 
-  .buttons-uaqb-5 > button:nth-child(1) > div:nth-child(1) > div:nth-child(1) > svg:nth-child(1) > path:nth-child(1) { 
+  .buttons-uaqb-5 > .grow-2T4nbg.colorBrand-2M3O3N.lookBlank-FgPMy6.button-ejjZWC { 
     display: none;
   }
 


### PR DESCRIPTION
The previous method only hid the button's visual aspect, but the button could still be tab-focused and clicked. This completely removes it.
I tested this on both my PC and laptop running Discord for Linux, and couldn't find any conflicting issues with other buttons, so I'm confident I did this correctly, but let me know if not.