### PR TITLE
Settings fixes and ad blocks, block super reaction buttons, "InvisibleTyping" plugin compatibility.

### DIFF
--- a/adblock.css
+++ b/adblock.css
@@ -34,6 +34,10 @@
     display: none
 }
 
+#profile-customization-tab > div > div.profileCustomizationSection__88eff > div.baseLayout_b00434 > div.sectionsContainer_a37883 > div.customizationSection__16fec:nth-of-type(4) {
+    display: none
+}
+
 #profile-customization-tab > div.container_d6bff4.containerDefaultMargin_dcee92.falloweenBackgroundImage__7e271 {
     display: none
 }


### PR DESCRIPTION
Blocks the "Falloween" ad, and removes super reaction buttons in chat.
Gift Button removal also removed the InvisibleTyping button from Strencher's plugin, this specifies the gift button with more precision.

Fixes a bug that would occur in the settings page, also removes the billing info buttons.
See FridgeRacer/discord-adblock@86d0ed922e1b19e90ac84e6d2888c31c7534deb2