### PR TITLE
Hides Nitro Upsells In Stream Quality Select Menu

### DIFF
--- a/adblock.css
+++ b/adblock.css
@@ -23,7 +23,7 @@ div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:first-child:h
 
 /* Makes The Fps Selector Smaller */
 div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:last-child:has(button[class*=selectorButtonPremiumRequired]) div[class*="group"] {
-    width: 183.27px;
+    width: 165.69px;
 }
 
 /* Restores Border Radius To New Last Button */

--- a/adblock.css
+++ b/adblock.css
@@ -18,7 +18,7 @@ div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:first-child:h
 
 /* Makes The Fps Selector Smaller */
 div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:last-child:has(button[class*=selectorButtonPremiumRequired]) div[class*="group"] {
-    width: 165.69px;
+    width: 106.84px;
 }
 
 /* Restores Border Radius To New Last Button */

--- a/adblock.css
+++ b/adblock.css
@@ -11,6 +11,10 @@ div[class*=upsellBanner] {
     display: none !important;
 }
 
+button[class*=selectorButtonPremiumRequired] {
+    display: none !important;
+}
+
 /* Chat view blocks */
 /* Nitro tab */
 [data-list-item-id*="___nitro"] {

--- a/adblock.css
+++ b/adblock.css
@@ -20,6 +20,10 @@ div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:first-child:h
     display: none !important;
 }
 
+div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:last-child:has(button[class*=selectorButtonPremiumRequired]) div[class*="group"] {
+    width: 183.27px;
+}
+
 /* Chat view blocks */
 /* Nitro tab */
 [data-list-item-id*="___nitro"] {

--- a/adblock.css
+++ b/adblock.css
@@ -6,6 +6,11 @@
 @author         Me
 ==/UserStyle== */
 
+/* Stream Quality Upsell */
+div[class*=upsellBanner] {
+    display: none !important;
+}
+
 /* Chat view blocks */
 /* Nitro tab */
 [data-list-item-id*="___nitro"] {

--- a/adblock.css
+++ b/adblock.css
@@ -15,6 +15,11 @@ button[class*=selectorButtonPremiumRequired] {
     display: none !important;
 }
 
+/* Hides Quality Selector If Nitro Button Upsell Present Due To There Only Being A Single Resolution Left! */
+div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:first-child:has(button[class*=selectorButtonPremiumRequired]) {
+    display: none !important;
+}
+
 /* Chat view blocks */
 /* Nitro tab */
 [data-list-item-id*="___nitro"] {

--- a/adblock.css
+++ b/adblock.css
@@ -11,11 +11,6 @@ div[class*=upsellBanner] {
     display: none !important;
 }
 
-/* Hides Premium Buttons In Quality Settings */
-div[class*="qualitySettingsContainer"] button[class*=selectorButtonPremiumRequired] {
-    display: none !important;
-}
-
 /* Hides Quality Selector If Nitro Button Upsell Present Due To There Only Being A Single Resolution Left! */
 div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:first-child:has(button[class*=selectorButtonPremiumRequired]) {
     display: none !important;

--- a/adblock.css
+++ b/adblock.css
@@ -11,6 +11,11 @@ div[class*=upsellBanner] {
     display: none !important;
 }
 
+/* Hides Premium Buttons In Quality Settings */
+div[class*="qualitySettingsContainer"] button[class*=selectorButtonPremiumRequired] {
+    display: none !important;
+}
+
 /* Hides Quality Selector If Nitro Button Upsell Present Due To There Only Being A Single Resolution Left! */
 div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:first-child:has(button[class*=selectorButtonPremiumRequired]) {
     display: none !important;

--- a/adblock.css
+++ b/adblock.css
@@ -11,7 +11,8 @@ div[class*=upsellBanner] {
     display: none !important;
 }
 
-button[class*=selectorButtonPremiumRequired] {
+/* Hides Premium Buttons In Quality Settings */
+div[class*="qualitySettingsContainer"] button[class*=selectorButtonPremiumRequired] {
     display: none !important;
 }
 
@@ -20,8 +21,14 @@ div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:first-child:h
     display: none !important;
 }
 
+/* Makes The Fps Selector Smaller */
 div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:last-child:has(button[class*=selectorButtonPremiumRequired]) div[class*="group"] {
     width: 183.27px;
+}
+
+/* Restores Border Radius To New Last Button */
+div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:last-child:has(button[class*=selectorButtonPremiumRequired]) div[class*="group"] button:nth-last-child(2) {
+    border-radius: 0 3px 3px 0;
 }
 
 /* Chat view blocks */


### PR DESCRIPTION
The Nitro Upsell Being Hidden:
![NitroUpsellHidden](https://github.com/CroissantDuNord/discord-adblock/assets/34137159/2be58627-0bb3-4768-b9eb-e085ac71633b)

What It Used To Look Like:
![Before](https://github.com/CroissantDuNord/discord-adblock/assets/34137159/5c641897-078e-498c-9457-8f7342005f2e)

Works With Fake Nitro:
![WhilstUsingFakeNitroPlugin](https://github.com/CroissantDuNord/discord-adblock/assets/34137159/f6debe7a-2e48-4a4c-966f-d4232578ae5c)
