### PR TITLE
Fix "jump to present" bar width

### DIFF
--- a/adblock.css
+++ b/adblock.css
@@ -41,8 +41,8 @@ div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:last-child:ha
 div[class^=channelAppLauncher_] {
   display: none;
 }
-[class^="jumpToPresentBar_"]{
-    right: 16px
+div[class^="jumpToPresentBar_"] {
+  right: 16px;
 }
 div[id="guild-header-popout-application-directory"] {
   display: none;

--- a/adblock.css
+++ b/adblock.css
@@ -41,6 +41,9 @@ div[class*="qualitySettingsContainer"] div[class*="settingsGroup"]:last-child:ha
 div[class^=channelAppLauncher_] {
   display: none;
 }
+[class^="jumpToPresentBar_"]{
+    right: 16px
+}
 div[id="guild-header-popout-application-directory"] {
   display: none;
 }


### PR DESCRIPTION
remove the right empty space from the "jump to present" bar added because of the app launcher button
this probably should be done to the "message failed to load" bar too but i couldn't make it appear